### PR TITLE
Prioritize start messages based on SendOn time

### DIFF
--- a/hm/send.go
+++ b/hm/send.go
@@ -41,8 +41,8 @@ func Send(l logger.Logger, conf *config.Config, poll bool) {
 func send(l logger.Logger, conf *config.Config, messageBus yagnats.NATSClient, store store.Store) error {
 	l.Info("Sending...")
 
-	sender := sender.New(store, metricsaccountant.New(store), conf, messageBus, buildTimeProvider(l), l)
-	err := sender.Send()
+	sender := sender.New(store, metricsaccountant.New(store), conf, messageBus, l)
+	err := sender.Send(buildTimeProvider(l))
 
 	if err != nil {
 		l.Error("Sender failed with error", err)

--- a/models/pending_messages.go
+++ b/models/pending_messages.go
@@ -113,7 +113,11 @@ type sortablePendingStartMessagesByPriority []PendingStartMessage
 func (s sortablePendingStartMessagesByPriority) Len() int      { return len(s) }
 func (s sortablePendingStartMessagesByPriority) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s sortablePendingStartMessagesByPriority) Less(i, j int) bool {
-	return s[i].Priority < s[j].Priority
+	diff := s[i].SendOn - s[j].SendOn
+	if diff == 0 {
+		return s[i].Priority > s[j].Priority
+	}
+	return diff < 0
 }
 
 func SortStartMessagesByPriority(messages map[string]PendingStartMessage) []PendingStartMessage {
@@ -123,7 +127,7 @@ func SortStartMessagesByPriority(messages map[string]PendingStartMessage) []Pend
 		sortedStartMessages[i] = message
 		i++
 	}
-	sort.Sort(sort.Reverse(sortedStartMessages))
+	sort.Sort(sortedStartMessages)
 	return sortedStartMessages
 }
 

--- a/models/pending_messages_test.go
+++ b/models/pending_messages_test.go
@@ -140,17 +140,17 @@ var _ = Describe("Pending Messages", func() {
 		})
 
 		Describe("Sorting start messages", func() {
-			It("should sort the passed in hash in order of decreasing priority", func() {
+			It("should sort the passed in hash in order of decreasing priority and time", func() {
 				startMessages := make(map[string]PendingStartMessage)
 				startMessages["A"] = NewPendingStartMessage(time.Unix(100, 0), 30, 10, "app-guid", "app-version", 1, 0.7, PendingStartMessageReasonCrashed)
-				startMessages["B"] = NewPendingStartMessage(time.Unix(100, 0), 30, 10, "app-guid", "app-version", 1, 0.5, PendingStartMessageReasonCrashed)
+				startMessages["B"] = NewPendingStartMessage(time.Unix(90, 0), 30, 10, "app-guid", "app-version", 1, 0.5, PendingStartMessageReasonCrashed)
 				startMessages["C"] = NewPendingStartMessage(time.Unix(100, 0), 30, 10, "app-guid", "app-version", 1, 1.0, PendingStartMessageReasonCrashed)
 
 				sortedStartMessage := SortStartMessagesByPriority(startMessages)
 				Ω(sortedStartMessage).Should(HaveLen(3))
-				Ω(sortedStartMessage[0].Priority).Should(Equal(1.0))
-				Ω(sortedStartMessage[1].Priority).Should(Equal(0.7))
-				Ω(sortedStartMessage[2].Priority).Should(Equal(0.5))
+				Ω(sortedStartMessage[0].Priority).Should(Equal(0.5))
+				Ω(sortedStartMessage[1].Priority).Should(Equal(1.0))
+				Ω(sortedStartMessage[2].Priority).Should(Equal(0.7))
 			})
 		})
 	})

--- a/sender/sender_test.go
+++ b/sender/sender_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Sender", func() {
 
 		storeAdapter = fakestoreadapter.New()
 		store = storepackage.NewStore(conf, storeAdapter, fakelogger.NewFakeLogger())
-		sender = New(store, metricsAccountant, conf, messageBus, timeProvider, fakelogger.NewFakeLogger())
+		sender = New(store, metricsAccountant, conf, messageBus, fakelogger.NewFakeLogger())
 		store.BumpActualFreshness(time.Unix(10, 0))
 		store.BumpDesiredFreshness(time.Unix(10, 0))
 	})
@@ -55,7 +55,7 @@ var _ = Describe("Sender", func() {
 		})
 
 		It("should return an error and not send any messages", func() {
-			err := sender.Send()
+			err := sender.Send(timeProvider)
 			Ω(err).Should(Equal(errors.New("oops")))
 			Ω(messageBus.PublishedMessages).Should(BeEmpty())
 		})
@@ -67,7 +67,7 @@ var _ = Describe("Sender", func() {
 		})
 
 		It("should return an error and not send any messages", func() {
-			err := sender.Send()
+			err := sender.Send(timeProvider)
 			Ω(err).Should(Equal(errors.New("oops")))
 			Ω(messageBus.PublishedMessages).Should(BeEmpty())
 		})
@@ -79,7 +79,7 @@ var _ = Describe("Sender", func() {
 		})
 
 		It("should return an error and not send any messages", func() {
-			err := sender.Send()
+			err := sender.Send(timeProvider)
 			Ω(err).Should(Equal(errors.New("oops")))
 			Ω(messageBus.PublishedMessages).Should(BeEmpty())
 		})
@@ -87,7 +87,7 @@ var _ = Describe("Sender", func() {
 
 	Context("when there are no start messages in the queue", func() {
 		It("should not send any messages", func() {
-			err := sender.Send()
+			err := sender.Send(timeProvider)
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(messageBus.PublishedMessages).Should(BeEmpty())
 		})
@@ -95,7 +95,7 @@ var _ = Describe("Sender", func() {
 
 	Context("when there are no stop messages in the queue", func() {
 		It("should not send any messages", func() {
-			err := sender.Send()
+			err := sender.Send(timeProvider)
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(messageBus.PublishedMessages).Should(BeEmpty())
 		})
@@ -116,7 +116,7 @@ var _ = Describe("Sender", func() {
 				pendingMessage,
 			)
 			storeAdapter.SetErrInjector = storeSetErrInjector
-			err = sender.Send()
+			err = sender.Send(timeProvider)
 		})
 
 		BeforeEach(func() {
@@ -286,7 +286,7 @@ var _ = Describe("Sender", func() {
 			)
 
 			storeAdapter.SetErrInjector = storeSetErrInjector
-			err = sender.Send()
+			err = sender.Send(timeProvider)
 		})
 
 		BeforeEach(func() {
@@ -461,7 +461,7 @@ var _ = Describe("Sender", func() {
 				pendingMessage,
 			)
 
-			err = sender.Send()
+			err = sender.Send(timeProvider)
 		})
 
 		BeforeEach(func() {
@@ -597,7 +597,7 @@ var _ = Describe("Sender", func() {
 				pendingMessage,
 			)
 
-			err = sender.Send()
+			err = sender.Send(timeProvider)
 		})
 
 		BeforeEach(func() {
@@ -744,7 +744,7 @@ var _ = Describe("Sender", func() {
 			conf, _ = config.DefaultConfig()
 			conf.SenderMessageLimit = 20
 
-			sender = New(store, metricsAccountant, conf, messageBus, timeProvider, fakelogger.NewFakeLogger())
+			sender = New(store, metricsAccountant, conf, messageBus, fakelogger.NewFakeLogger())
 
 			desiredStates := []models.DesiredAppState{}
 			for i := 0; i < 40; i += 1 {
@@ -786,7 +786,7 @@ var _ = Describe("Sender", func() {
 			store.SyncDesiredState(desiredStates...)
 
 			timeProvider.TimeToProvide = time.Unix(130, 0)
-			err := sender.Send()
+			err := sender.Send(timeProvider)
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 


### PR DESCRIPTION
@onsi 
Here is the first stage of the changes which just does a simple compare of SendOn.
We were wondering if we should do some linear priority bump based on the length of time beyond SendOn, e.g., every X seconds beyond SendOn, your priority increases by Y points.

This current version is the simplest and easiest to understand.
