### PR TITLE
Losing the lock is not an error

### DIFF
--- a/hm/common.go
+++ b/hm/common.go
@@ -93,7 +93,7 @@ func acquireLock(l logger.Logger, conf *config.Config, lockName string) {
 					lockAcquired = nil
 				}
 			} else {
-				l.Error("Lost the lock", errors.New("Lost the lock"))
+				l.Info("Lost the lock")
 				os.Exit(197)
 			}
 		}


### PR DESCRIPTION
Drop the log level when losing a lock.  Its expected behavior.

[#82205318]
